### PR TITLE
Prevent script from flipping image up/down

### DIFF
--- a/FitShow.py
+++ b/FitShow.py
@@ -57,7 +57,7 @@ if len(argv) < 3:
             -color: display numbers with colors (default=False).")
 
 if cube != '':
-	fit = getdata(cube)
+	fit = np.flipud(getdata(cube))
 	shape = fit.shape
 	print('Initial image shape', shape)
 	if xmax is None: xmax = shape[2]


### PR DESCRIPTION
Because numpy indexes from above and going down, but y coords are usually indexed from below and up.

Also, "flip ud" means "freak out" in Danish...